### PR TITLE
lmmx/async fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,10 +346,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "futures-sink"
@@ -354,8 +391,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -478,6 +517,7 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 name = "httpolars"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "jemallocator",
  "polars",
  "pyo3",
@@ -485,6 +525,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1612,6 +1653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,18 +1866,32 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ serde = { version = "1", features = ["derive"] }
 polars = { version = "0.39.2", default-features = false }
 reqwest = { version = "0.12.4", features = ["blocking"] }
 serde_json = "1.0.117"
+tokio = { version = "1.38.0", features = ["full"] }
+futures = "0.3.30"
 
 [lib]
 name = "_lib"

--- a/src/api.rs
+++ b/src/api.rs
@@ -45,7 +45,7 @@ pub async fn make_request(client: Client, endpoint: &String, params: &HashMap<&s
         .get(endpoint)
         .query(&params)
         .send()
-        .await?;
+        .await;
     
     match response_result {
         Ok(response) => {

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -13,7 +13,6 @@ struct ApiCallKwargs {
     endpoint: String,
 }
 
-#[tokio::main]
 async fn handle_api_response(client: Client, endpoint: &String, params: &HashMap<&str, &str>) -> Option<String> {
     match make_request(client, endpoint, params).await {
         Ok((text, status_code)) => {
@@ -52,7 +51,7 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                             let name_owned = name.clone();
                             let mut params = HashMap::new();
                             params.insert(name_owned.as_str(), v);
-                            handle_api_response(client, &endpoint, &params)
+                            handle_api_response(client, &endpoint, &params).await
                         }
                         None => None
                     }
@@ -83,7 +82,7 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
                             params.insert(name_owned.as_str(), v_str.as_str());
-                            handle_api_response(client, &endpoint, &params)
+                            handle_api_response(client, &endpoint, &params).await
                         }
                         None => None
                     }
@@ -114,7 +113,7 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
                             params.insert(name_owned.as_str(), v_str.as_str());
-                            handle_api_response(client, &endpoint, &params)
+                            handle_api_response(client, &endpoint, &params).await
                         }
                         None => None
                     }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -41,94 +41,97 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
         DataType::String => {
             let ca = s.str()?;
             let rt = Runtime::new().unwrap();
-            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
-                tokio::spawn(async move {
-                    match opt_v_owned {
-                        Some(v) => {
-                            let name_owned = name.clone();
-                            let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v.as_str());
-                            handle_api_response(client, &endpoint, &params).await
+            let texts: Vec<Option<String>> = rt.block_on(async {
+                let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                    let client = client.clone();
+                    let endpoint = endpoint.clone();
+                    let name = name.clone();
+                    let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
+                    tokio::spawn(async move {
+                        match opt_v_owned {
+                            Some(v) => {
+                                let name_owned = name.clone();
+                                let mut params = HashMap::new();
+                                params.insert(name_owned.as_str(), v.as_str());
+                                handle_api_response(client, &endpoint, &params).await
+                            }
+                            None => None
                         }
-                        None => None
+                    })
+                }).collect();
+                let results = join_all(futures).await;
+                results.into_iter().map(|res| {
+                    match res {
+                        Ok(opt) => opt,
+                        Err(_) => None, // Handle the join error if needed
                     }
-                })
-            }).collect();
-            let results = rt.block_on(async {
-                join_all(futures).await
+                }).collect()
             });
-            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
-                match res {
-                    Ok(opt) => opt,
-                    Err(_) => None, // Handle the join error if needed
-                }
-            }).collect();
+
             StringChunked::from_iter(texts)
         },
         DataType::Int32 => {
             let ca = s.i32()?;
             let rt = Runtime::new().unwrap();
-            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
-                tokio::spawn(async move {
-                    match opt_v_owned {
-                        Some(v) => {
-                            let name_owned = name.clone();
-                            let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v.as_str());
-                            handle_api_response(client, &endpoint, &params).await
+            let texts: Vec<Option<String>> = rt.block_on(async {
+                let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                    let client = client.clone();
+                    let endpoint = endpoint.clone();
+                    let name = name.clone();
+                    let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
+                    tokio::spawn(async move {
+                        match opt_v_owned {
+                            Some(v) => {
+                                let name_owned = name.clone();
+                                let mut params = HashMap::new();
+                                params.insert(name_owned.as_str(), v.as_str());
+                                handle_api_response(client, &endpoint, &params).await
+                            }
+                            None => None
                         }
-                        None => None
+                    })
+                }).collect();
+                let results = join_all(futures).await;
+                results.into_iter().map(|res| {
+                    match res {
+                        Ok(opt) => opt,
+                        Err(_) => None, // Handle the join error if needed
                     }
-                })
-            }).collect();
-            let results = rt.block_on(async {
-                join_all(futures).await
+                }).collect()
             });
-            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
-                match res {
-                    Ok(opt) => opt,
-                    Err(_) => None, // Handle the join error if needed
-                }
-            }).collect();
+
             StringChunked::from_iter(texts)
         },
         DataType::Int64 => {
             let ca = s.i64()?;
             let rt = Runtime::new().unwrap();
-            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
-                tokio::spawn(async move {
-                    match opt_v_owned {
-                        Some(v) => {
-                            let name_owned = name.clone();
-                            let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v.as_str());
-                            handle_api_response(client, &endpoint, &params).await
+            let texts: Vec<Option<String>> = rt.block_on(async {
+                let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                    let client = client.clone();
+                    let endpoint = endpoint.clone();
+                    let name = name.clone();
+                    let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
+                    tokio::spawn(async move {
+                        match opt_v_owned {
+                            Some(v) => {
+                                let name_owned = name.clone();
+                                let mut params = HashMap::new();
+                                params.insert(name_owned.as_str(), v.as_str());
+                                handle_api_response(client, &endpoint, &params).await
+                            }
+                            None => None
                         }
-                        None => None
+                    })
+                }).collect();
+                let results = join_all(futures).await;
+                results.into_iter().map(|res| {
+                    match res {
+                        Ok(opt) => opt,
+                        Err(_) => None, // Handle the join error if needed
                     }
-                })
-            }).collect();
-            let results = rt.block_on(async {
-                join_all(futures).await
+                }).collect()
             });
-            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
-                match res {
-                    Ok(opt) => opt,
-                    Err(_) => None, // Handle the join error if needed
-                }
-            }).collect();
+
             StringChunked::from_iter(texts)
         },
         dtype => polars_bail!(InvalidOperation:format!("Data type {dtype} not \

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -43,16 +43,17 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.str()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
-                    let mut params = HashMap::new();
-                    params.insert(name, v);
-                    params
-                });
-				tokio::spawn(async move {
-                    handle_api_response(client, &endpoint, &params)
+                tokio::spawn(async move {
+                    match opt_v {
+                        Some(v) => {
+                            let client = client.clone();
+                            let endpoint = endpoint.clone();
+                            let mut params = HashMap::new();
+                            params.insert(name.clone(), v);
+                            handle_api_response(client, &endpoint, &params)
+                        }
+                        None => None
+                    }
                 })
             }).collect();
             let results = rt.block_on(async {
@@ -70,17 +71,18 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.i32()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
-                    let mut params = HashMap::new();
-                    let v_str = v.to_string();
-                    params.insert(name, v_str.as_str());
-                    params
-                });
-				tokio::spawn(async move {
-                    handle_api_response(client, &endpoint, &params)
+                tokio::spawn(async move {
+                    match opt_v {
+                        Some(v) => {
+                            let client = client.clone();
+                            let endpoint = endpoint.clone();
+                            let v_str = v.to_string();
+                            let mut params = HashMap::new();
+                            params.insert(name.clone(), v_str.as_str());
+                            handle_api_response(client, &endpoint, &params)
+                        }
+                        None => None
+                    }
                 })
             }).collect();
             let results = rt.block_on(async {
@@ -98,17 +100,18 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.i64()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
-                let client = client.clone();
-                let endpoint = endpoint.clone();
-                let name = name.clone();
-                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
-                    let mut params = HashMap::new();
-                    let v_str = v.to_string();
-                    params.insert(name, v_str.as_str());
-                    params
-                });
-				tokio::spawn(async move {
-                    handle_api_response(client, &endpoint, &params)
+                tokio::spawn(async move {
+                    match opt_v {
+                        Some(v) => {
+                            let client = client.clone();
+                            let endpoint = endpoint.clone();
+                            let v_str = v.to_string();
+                            let mut params = HashMap::new();
+                            params.insert(name.clone(), v_str.as_str());
+                            handle_api_response(client, &endpoint, &params)
+                        }
+                        None => None
+                    }
                 })
             }).collect();
             let results = rt.block_on(async {

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -45,12 +45,13 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
                 let name = name.clone();
+                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
                 tokio::spawn(async move {
-                    match opt_v {
+                    match opt_v_owned {
                         Some(v) => {
                             let name_owned = name.clone();
                             let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v);
+                            params.insert(name_owned.as_str(), v.as_str());
                             handle_api_response(client, &endpoint, &params).await
                         }
                         None => None
@@ -75,13 +76,13 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
                 let name = name.clone();
+                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
                 tokio::spawn(async move {
-                    match opt_v {
+                    match opt_v_owned {
                         Some(v) => {
                             let name_owned = name.clone();
-                            let v_str = v.to_string();
                             let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v_str.as_str());
+                            params.insert(name_owned.as_str(), v.as_str());
                             handle_api_response(client, &endpoint, &params).await
                         }
                         None => None
@@ -106,13 +107,13 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
                 let name = name.clone();
+                let opt_v_owned = opt_v.map(|v| v.to_string()); // Convert opt_v to an owned String
                 tokio::spawn(async move {
-                    match opt_v {
+                    match opt_v_owned {
                         Some(v) => {
                             let name_owned = name.clone();
-                            let v_str = v.to_string();
                             let mut params = HashMap::new();
-                            params.insert(name_owned.as_str(), v_str.as_str());
+                            params.insert(name_owned.as_str(), v.as_str());
                             handle_api_response(client, &endpoint, &params).await
                         }
                         None => None

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -43,11 +43,11 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.str()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
-                            let client = client.clone();
-                            let endpoint = endpoint.clone();
                             let mut params = HashMap::new();
                             params.insert(name.clone(), v);
                             handle_api_response(client, &endpoint, &params)
@@ -71,11 +71,11 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.i32()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
-                            let client = client.clone();
-                            let endpoint = endpoint.clone();
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
                             params.insert(name.clone(), v_str.as_str());
@@ -100,11 +100,11 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let ca = s.i64()?;
             let rt = Runtime::new().unwrap();
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
-                            let client = client.clone();
-                            let endpoint = endpoint.clone();
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
                             params.insert(name.clone(), v_str.as_str());

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -4,14 +4,18 @@ use pyo3_polars::derive::polars_expr;
 use serde::Deserialize;
 use std::collections::HashMap;
 use crate::api::{make_request, ApiError, ApiResponse};
+use reqwest::Client;
+use tokio::runtime::Runtime;
+use futures::future::join_all;
 
 #[derive(Deserialize)]
 struct ApiCallKwargs {
     endpoint: String,
 }
 
-fn handle_api_response(endpoint: &String, params: &HashMap<&str, &str>) -> Option<String> {
-    match make_request(endpoint, params) {
+#[tokio::main]
+async fn handle_api_response(client: Client, endpoint: &String, params: &HashMap<&str, &str>) -> Option<String> {
+    match make_request(client, endpoint, params).await {
         Ok((text, status_code)) => {
             let response = ApiResponse { text, status_code };
             Some(serde_json::to_string(&response).unwrap())
@@ -33,39 +37,88 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
     let s = &inputs[0];
     let name = s.name();
     let endpoint = &kwargs.endpoint;
+    let client = Client::new();
     let response_texts = match s.dtype() {
         DataType::String => {
             let ca = s.str()?;
-            let texts: Vec<Option<String>> = ca.into_iter().map(|opt_v| {
-                opt_v.map_or(None, |v| {
+            let rt = Runtime::new().unwrap();
+            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
+                let name = name.clone();
+                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
                     let mut params = HashMap::new();
                     params.insert(name, v);
-                    handle_api_response(endpoint, &params)
+                    params
+                });
+				tokio::spawn(async move {
+                    handle_api_response(client, &endpoint, &params)
                 })
+            }).collect();
+            let results = rt.block_on(async {
+                join_all(futures).await
+            });
+            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
+                match res {
+                    Ok(opt) => opt,
+                    Err(_) => None, // Handle the join error if needed
+                }
             }).collect();
             StringChunked::from_iter(texts)
         },
         DataType::Int32 => {
             let ca = s.i32()?;
-            let texts: Vec<Option<String>> = ca.into_iter().map(|opt_v| {
-                opt_v.map_or(None, |v| {
+            let rt = Runtime::new().unwrap();
+            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
+                let name = name.clone();
+                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
                     let mut params = HashMap::new();
                     let v_str = v.to_string();
                     params.insert(name, v_str.as_str());
-                    handle_api_response(endpoint, &params)
+                    params
+                });
+				tokio::spawn(async move {
+                    handle_api_response(client, &endpoint, &params)
                 })
+            }).collect();
+            let results = rt.block_on(async {
+                join_all(futures).await
+            });
+            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
+                match res {
+                    Ok(opt) => opt,
+                    Err(_) => None, // Handle the join error if needed
+                }
             }).collect();
             StringChunked::from_iter(texts)
         },
         DataType::Int64 => {
             let ca = s.i64()?;
-            let texts: Vec<Option<String>> = ca.into_iter().map(|opt_v| {
-                opt_v.map_or(None, |v| {
+            let rt = Runtime::new().unwrap();
+            let futures: Vec<_> = ca.into_iter().map(|opt_v| {
+                let client = client.clone();
+                let endpoint = endpoint.clone();
+                let name = name.clone();
+                let params: HashMap<&str, &str> = opt_v.map_or(HashMap::new(), |v| {
                     let mut params = HashMap::new();
                     let v_str = v.to_string();
                     params.insert(name, v_str.as_str());
-                    handle_api_response(endpoint, &params)
+                    params
+                });
+				tokio::spawn(async move {
+                    handle_api_response(client, &endpoint, &params)
                 })
+            }).collect();
+            let results = rt.block_on(async {
+                join_all(futures).await
+            });
+            let texts: Vec<Option<String>> = results.into_iter().map(|res| {
+                match res {
+                    Ok(opt) => opt,
+                    Err(_) => None, // Handle the join error if needed
+                }
             }).collect();
             StringChunked::from_iter(texts)
         },

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -35,7 +35,7 @@ async fn handle_api_response(client: Client, endpoint: &String, params: &HashMap
 #[polars_expr(output_type=String)]
 fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
     let s = &inputs[0];
-    let name = s.name();
+    let name = s.name().to_string();
     let endpoint = &kwargs.endpoint;
     let client = Client::new();
     let response_texts = match s.dtype() {
@@ -45,11 +45,13 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
+                let name = name.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
+                            let name_owned = name.clone();
                             let mut params = HashMap::new();
-                            params.insert(name.clone(), v);
+                            params.insert(name_owned.as_str(), v);
                             handle_api_response(client, &endpoint, &params)
                         }
                         None => None
@@ -73,12 +75,14 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
+                let name = name.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
+                            let name_owned = name.clone();
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
-                            params.insert(name.clone(), v_str.as_str());
+                            params.insert(name_owned.as_str(), v_str.as_str());
                             handle_api_response(client, &endpoint, &params)
                         }
                         None => None
@@ -102,12 +106,14 @@ fn api_call(inputs: &[Series], kwargs: ApiCallKwargs) -> PolarsResult<Series> {
             let futures: Vec<_> = ca.into_iter().map(|opt_v| {
                 let client = client.clone();
                 let endpoint = endpoint.clone();
+                let name = name.clone();
                 tokio::spawn(async move {
                     match opt_v {
                         Some(v) => {
+                            let name_owned = name.clone();
                             let v_str = v.to_string();
                             let mut params = HashMap::new();
-                            params.insert(name.clone(), v_str.as_str());
+                            params.insert(name_owned.as_str(), v_str.as_str());
                             handle_api_response(client, &endpoint, &params)
                         }
                         None => None


### PR DESCRIPTION
- feat: Initial attempt to introduce async HTTP calls
- refactor: handle Option type within tokio spawn closure
- refactor: move the client out of the tokio spawn
- fix: don't propagate awaitable error
- fix: correct name lifetime
- refactor: await the async function call, don't use tokio main on it
- fix: convert string reference to owned (static lifetime) for spawning
- fix: move all tokio spawn into runtime closure
